### PR TITLE
Update alternative provider syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     - auth:
         password: $DOCKER_PASSWORD
         username: $DOCKER_USERNAME
-      image: trussworks/circleci:efb1042e31538677779971798e0912390f699e72
+      image: trussworks/circleci:caa7ee5c649b541f3fde6473d32b045bcfdb93ef
     steps:
     - checkout
     - restore_cache:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -12,17 +12,17 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.26.0
+    rev: v0.28.1
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.50.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
 
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.33.0
+    rev: v1.41.1
     hooks:
       - id: golangci-lint

--- a/README.md
+++ b/README.md
@@ -61,35 +61,52 @@ domains `my-app.int.my-corp.com` and `my-other-app.int.my-corp.com`.
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
-| aws | >= 3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_auth_domain_certificate"></a> [auth\_domain\_certificate](#module\_auth\_domain\_certificate) | trussworks/acm-cert/aws | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cognito_identity_provider.saml](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_identity_provider) | resource |
+| [aws_cognito_user_pool.saml](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool) | resource |
+| [aws_cognito_user_pool_client.saml](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool_client) | resource |
+| [aws_cognito_user_pool_domain.saml](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool_domain) | resource |
+| [aws_route53_record.cognito_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.cognito_auth_ipv6](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_zone.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| dns\_name | DNS name for the authenticate page (e.g. `auth.my-company.com`) | `string` | n/a | yes |
-| environment | Environment tag. e.g. prod | `string` | n/a | yes |
-| name | Name for the various cognito resources | `string` | n/a | yes |
-| relying\_party\_dns\_names | List of DNS names for the relying parties (i.e. the applications you are authenticating with this) | `list(string)` | n/a | yes |
-| saml\_metadata\_file\_content | Contents of the SAML metadata file | `string` | n/a | yes |
-| saml\_metadata\_sso\_redirect\_binding\_uri | The HTTP-Redirect SSO binding from the SAML metadata file. Must be kept in sync with saml\_metadata\_file\_content! | `string` | n/a | yes |
-| zone\_id | Route53 zone id to put DNS records in | `string` | n/a | yes |
+| <a name="input_dns_name"></a> [dns\_name](#input\_dns\_name) | DNS name for the authenticate page (e.g. `auth.my-company.com`) | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment tag. e.g. prod | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name for the various cognito resources | `string` | n/a | yes |
+| <a name="input_relying_party_dns_names"></a> [relying\_party\_dns\_names](#input\_relying\_party\_dns\_names) | List of DNS names for the relying parties (i.e. the applications you are authenticating with this) | `list(string)` | n/a | yes |
+| <a name="input_saml_metadata_file_content"></a> [saml\_metadata\_file\_content](#input\_saml\_metadata\_file\_content) | Contents of the SAML metadata file | `string` | n/a | yes |
+| <a name="input_saml_metadata_sso_redirect_binding_uri"></a> [saml\_metadata\_sso\_redirect\_binding\_uri](#input\_saml\_metadata\_sso\_redirect\_binding\_uri) | The HTTP-Redirect SSO binding from the SAML metadata file. Must be kept in sync with saml\_metadata\_file\_content! | `string` | n/a | yes |
+| <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | Route53 zone id to put DNS records in | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| cognito\_user\_pool\_arn | ARN for the Cognito User Pool |
-| cognito\_user\_pool\_client\_id | ID for the Cognito User Pool Client |
-| cognito\_user\_pool\_domain | Name for the Cognito User Pool Domain |
-
+| <a name="output_cognito_user_pool_arn"></a> [cognito\_user\_pool\_arn](#output\_cognito\_user\_pool\_arn) | ARN for the Cognito User Pool |
+| <a name="output_cognito_user_pool_client_id"></a> [cognito\_user\_pool\_client\_id](#output\_cognito\_user\_pool\_client\_id) | ID for the Cognito User Pool Client |
+| <a name="output_cognito_user_pool_domain"></a> [cognito\_user\_pool\_domain](#output\_cognito\_user\_pool\_domain) | Name for the Cognito User Pool Domain |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Attribution

--- a/providers.tf
+++ b/providers.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  alias = "us-east-1"
-}

--- a/versions.tf
+++ b/versions.tf
@@ -1,8 +1,9 @@
 terraform {
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 3.0"
+      source                = "hashicorp/aws"
+      version               = ">= 3.0"
+      configuration_aliases = [aws.us-east-1]
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
Terraform 0.15 changed the way to call alternate providers and right now this module generates a warning because it's still using the old syntax. This PR updates things according to https://www.terraform.io/upgrade-guides/0-15.html#alternative-provider-configurations-within-modules.