### PR TITLE
deprecate older terraform versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,12 +34,6 @@ repos:
     hooks:
       - id: shell-lint
 
-  - repo: https://github.com/terraform-docs/terraform-docs
-    rev: "v0.16.0"
-    hooks:
-      - id: terraform-docs-go
-        args: ["markdown", "table", "--output-file", "README.md", "."]
-
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.77.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ domains `my-app.int.my-corp.com` and `my-other-app.int.my-corp.com`.
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
+| terraform | >= 1.0 |
 | aws | >= 3.0 |
 
 ## Providers

--- a/README.md
+++ b/README.md
@@ -51,11 +51,6 @@ This will leave you with Cognito resources, that use
 SAML IDP. It can be used to provide authentication for apps running on the
 domains `my-app.int.my-corp.com` and `my-other-app.int.my-corp.com`.
 
-
-## Terraform Versions
-
-- Terraform 0.13 and newer. Pin module version to ~> 3.0. Submit pull requests to `main` branch.
-
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,5 @@ terraform {
       configuration_aliases = [aws.us-east-1]
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
 }


### PR DESCRIPTION
-   Modified README
-   Set expected terraform version to be equal or greater than Terraform version 1.0
