### PR TITLE
Remove unsupported acm environment argument, ignore computed value of ActiveEncryptionCertificate

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,6 @@ module "auth_domain_certificate" {
 
   domain_name = var.dns_name
   zone_id     = data.aws_route53_zone.selected.id
-  environment = var.environment
 
   providers = {
     aws = aws.us-east-1


### PR DESCRIPTION
- in the trussworks/aws-acm module, `environment` was removed from its variables.  since a ref wasn't pinned before the most appropriate course of action seems to be to remove the arg from its usage here
- ActiveEncryptionCertificate is a computed value and the provider attempts to set it to null for every apply, so ignore changes to it