### PR TITLE
chore: update aws provider version

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   validate-tf:
-    uses: trussworks/shared-actions/.github/workflows/validate-tf.yml@main
+    uses: trussworks/shared-actions/.github/workflows/validate-tf.yml@637d269a81479673b19d9e7b02b98d75b1805b46 #v0.1.1

--- a/versions.tf
+++ b/versions.tf
@@ -2,9 +2,9 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 3.0"
+      version               = "~> 5.0"
       configuration_aliases = [aws.us-east-1]
     }
   }
-  required_version = ">= 1.0"
+  required_version = "~> 1.0"
 }


### PR DESCRIPTION
This removes the version constraint `>= 3.0` to match a more modern AWS provider version.
